### PR TITLE
Add header file for `unlink`

### DIFF
--- a/src/grid_io.c
+++ b/src/grid_io.c
@@ -11,6 +11,7 @@ static const char grid_io_c_rcsid[]="$Id$";
 #include "matrix.h"
 #define grid_io_c_
 #include "grid_io.h"
+#include <unistd.h>
 
 #ifndef MAX_ROW_BUFFER_SIZE
 #define MAX_ROW_BUFFER_SIZE (2*1024*1024)

--- a/src/mapx.c
+++ b/src/mapx.c
@@ -1216,7 +1216,7 @@ static int forward_xy_mapx_check (int status, mapx_class *this,
     dist = dist_latlon_map_units(this, lat, lon, lat2, lon2);
     if (errno != 0) 
       status = -1;
-    if (status != 0 || !finite(dist) || dist > this->maximum_error) {
+    if (status != 0 || !isfinite(dist) || dist > this->maximum_error) {
       *x = NAN;
       *y = NAN;
       status = -1;
@@ -1251,7 +1251,7 @@ static int inverse_xy_mapx_check (int status, mapx_class *this,
     dist = dist_xy_map_units(this, x, y, x2, y2);
     if (errno != 0) 
       status = -1;
-    if (status != 0 || !finite(dist) || dist > this->maximum_error) {
+    if (status != 0 || !isfinite(dist) || dist > this->maximum_error) {
       *lat = NAN;
       *lon = NAN;
       status = -1;

--- a/src/mapx.h
+++ b/src/mapx.h
@@ -123,16 +123,16 @@ typedef struct {
 mapx_class *init_mapx(char *filename);
 mapx_class *new_mapx(char *label, bool quiet);
 char *next_line_from_buffer(char *bufptr, char *readln);
-void close_mapx(mapx_class *this);
-int reinit_mapx(mapx_class *this);
-int within_mapx(mapx_class *this, double lat, double lon);
-int forward_mapx(mapx_class *this,
+void close_mapx(mapx_class *this_class);
+int reinit_mapx(mapx_class *this_class);
+int within_mapx(mapx_class *this_class, double lat, double lon);
+int forward_mapx(mapx_class *this_class,
 		 double lat, double lon, double *u, double *v);
-int inverse_mapx(mapx_class *this,
+int inverse_mapx(mapx_class *this_class,
 		 double u, double v, double *lat, double *lon);
-int forward_xy_mapx(mapx_class *this,
+int forward_xy_mapx(mapx_class *this_class,
 		    double lat, double lon, double *x, double *y);
-int inverse_xy_mapx(mapx_class *this,
+int inverse_xy_mapx(mapx_class *this_class,
 		    double x, double u, double *lat, double *lon);
 
 #endif


### PR DESCRIPTION
Please consider this minor bug fix for mapx. Thank you for the code :)

This commit adds an include statement for `unistd.h` to grid_io.c, defining the `unlink` function. Without this, the code does not compile on Apple clang version 13.1.6 (clang-1316.0.21.2.5), with the following error message:

grid_io.c:101:7: error: implicit declaration of function 'unlink' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      unlink(filename);
      ^