### PR TITLE
Updated the obsolete ftp location for mapx maps files to GitHub repo.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -34,10 +34,10 @@ See the README file for contact information if you need help.
 ---------------------------------------------------------------------------
 
 To get started with a copy of the map projection parameter (.mpp) and grid
-parameter definition (.gpd) files already in use at NSIDC, download and
-uncompress the maps file from here:
+parameter definition (.gpd) files defined and used at NSIDC, clone the mapxmaps
+repository from:
 
-ftp://sidads.colorado.edu/pub/tools/mapx/nsidc_maps.tar.gz
+https://github.com/nsidc/mapxmaps
 
 Follow the instructions in the included README file for setting up your
 environment to point the mapx library to these .mpp/.gpd files.  Sometimes


### PR DESCRIPTION
Note that T. Haran's README-UTMupgrade also contains obsolete references to the old cvs locaiton for maps files. I left this alone in favor of fixing the locaiton in the general INSTALL file.